### PR TITLE
Allow adding to wartremover classpath for using custom warts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ Usage
 	    errorWarts.add('Product') // set of warts to use - violation causes error; default is empty set
 	    warningWarts.add('Product') // set of warts to use - violation causes warning; default is set of all stable warts
 	    excludedFiles.add('src/main/scala/me/project/Main.scala') // set of file to be excluded; default is empty
-        additionalWarts.add(new File("path/to/yourWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default is empty
+        classPaths.add(new File("path/to/yourWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default is empty
 	    test {
 	        errorWarts.add('Serializable') // set of warts to use - violation causes error; default settings from the block above
             warningWarts.add('Serializable') // set of warts to use - violation causes warning; default settings from the block above
             excludedFiles.add('src/test/scala/me/project/Test.scala') // set of file to be excluded; default settings from the block above
-            additionalWarts.add(new File("path/to/yourTestWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default settings from the block above
+            classPaths.add(new File("path/to/yourTestWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default settings from the block above
 	    }
 	}
 	

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Usage
 	    errorWarts.add('Product') // set of warts to use - violation causes error; default is empty set
 	    warningWarts.add('Product') // set of warts to use - violation causes warning; default is set of all stable warts
 	    excludedFiles.add('src/main/scala/me/project/Main.scala') // set of file to be excluded; default is empty
+        additionalWarts.add(new File("path/to/yourWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default is empty
 	    test {
 	        errorWarts.add('Serializable') // set of warts to use - violation causes error; default settings from the block above
             warningWarts.add('Serializable') // set of warts to use - violation causes warning; default settings from the block above
             excludedFiles.add('src/test/scala/me/project/Test.scala') // set of file to be excluded; default settings from the block above
+            additionalWarts.add(new File("path/to/yourTestWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default settings from the block above
 	    }
 	}
 	

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
@@ -25,7 +25,7 @@ class WartremoverPlugin implements Plugin<Project> {
                 scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.warningWarts.collect { getWarningWartDirective(it) })
                 scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.excludedFiles.collect { getExludedFileDirective(project.file(it).canonicalPath) })
 
-                scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.additionalWarts.collect { getClasspathDirective(it) })
+                scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.classPaths.collect { getClasspathDirective(it) })
             }
         }
     }

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
@@ -24,6 +24,8 @@ class WartremoverPlugin implements Plugin<Project> {
                 scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.errorWarts.collect { getErrorWartDirective(it) })
                 scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.warningWarts.collect { getWarningWartDirective(it) })
                 scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.excludedFiles.collect { getExludedFileDirective(project.file(it).canonicalPath) })
+
+                scalaTask.scalaCompileOptions.additionalParameters.addAll(settings.additionalWarts.collect { getClasspathDirective(it) })
             }
         }
     }
@@ -78,5 +80,9 @@ class WartremoverPlugin implements Plugin<Project> {
 
     private String getExludedFileDirective(String absoluteFileName) {
         '-P:wartremover:excluded:' + absoluteFileName
+    }
+
+    private String getClasspathDirective(String classpath) {
+        '-P:wartremover:cp:' + classpath
     }
 }

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
@@ -19,14 +19,14 @@ class WartremoverSettings {
                                 'TryPartial',
                                 'Var']
     Set<String> excludedFiles = []
-    Set<String> additionalWarts = []
+    Set<String> classPaths = []
 
     WartremoverSettings deepClone() {
         def r = new WartremoverSettings()
         r.errorWarts = this.errorWarts.toSet()
         r.warningWarts = this.warningWarts.toSet()
         r.excludedFiles = this.excludedFiles.toSet()
-        r.additionalWarts = this.additionalWarts.toSet()
+        r.classPaths = this.classPaths.toSet()
         r
     }
 }

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
@@ -19,12 +19,14 @@ class WartremoverSettings {
                                 'TryPartial',
                                 'Var']
     Set<String> excludedFiles = []
+    Set<String> additionalWarts = []
 
     WartremoverSettings deepClone() {
         def r = new WartremoverSettings()
         r.errorWarts = this.errorWarts.toSet()
         r.warningWarts = this.warningWarts.toSet()
         r.excludedFiles = this.excludedFiles.toSet()
+        r.additionalWarts = this.additionalWarts.toSet()
         r
     }
 }


### PR DESCRIPTION
Now say you have some package mywarts.coolwarts and a wart you would like to use MyWart,
adding mywarts.coolwarts.MyWart as an errorWart and then adding the appropriate path to
additionalWarts will allow wartremover to pick up MyWart.

Relates to https://github.com/augi/gradle-wartremover/issues/31