### PR TITLE
chore: Upgrade scala 2.1x to latest wartremover (2.4.21)

### DIFF
--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverPlugin.groovy
@@ -33,11 +33,11 @@ class WartremoverPlugin implements Plugin<Project> {
         Integer scalaMinorVersion = scalaVersion.split('\\.').takeRight(1).join('').toInteger() // 2.12.3 -> 3
         if (scalaMajorVersion == '2.10') '2.10:2.3.7'
         else if (scalaMajorVersion == '2.11') {
-            scalaMinorVersion >= 12 ? "$scalaVersion:2.4.20" : '2.11:2.4.16'
+            scalaMinorVersion >= 12 ? "$scalaVersion:2.4.21" : '2.11:2.4.16'
         } else if (scalaMajorVersion == '2.12') {
-            scalaMinorVersion >= 10 ? "$scalaVersion:2.4.20" : (scalaMinorVersion >= 8 ? "$scalaVersion:2.4.13" : '2.12:2.4.16')
+            scalaMinorVersion >= 10 ? "$scalaVersion:2.4.21" : (scalaMinorVersion >= 8 ? "$scalaVersion:2.4.13" : '2.12:2.4.16')
         } else if (scalaMajorVersion == '2.13') {
-            "$scalaVersion:2.4.20"
+            "$scalaVersion:2.4.21"
         } else {
             throw new RuntimeException("Unsupported Scala version: $scalaVersion")
         }


### PR DESCRIPTION
Adds support for scala versions 2.13.12, 2.13.11