### PR TITLE
Add Scala and wartremover version properties, tidy up tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,43 @@ If you want to have different settings for tests then you can use the `test` blo
 
 > Please note that since `0.15.0` version at least Gradle 6.4 is required (because the plugin uses `scalaCompilerPlugins` configuration).
 
-Usage
-=====
+## Usage
+
 The plugin is published to [Gradle Plugins portal](https://plugins.gradle.org/plugin/cz.augi.gradle.wartremover)
 
     plugins {
-      id 'cz.augi.gradle.wartremover' version 'putCurrentVersionHere'
+      id 'cz.augi.gradle.wartremover' version '<putCurrentVersionHere>'
     }
-	
-	wartremover {
-	    errorWarts.add('Product') // set of warts to use - violation causes error; default is empty set
-	    warningWarts.add('Product') // set of warts to use - violation causes warning; default is set of all stable warts
-	    excludedFiles.add('src/main/scala/me/project/Main.scala') // set of file to be excluded; default is empty
-        classPaths.add(new File("path/to/yourWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default is empty
-	    test {
-	        errorWarts.add('Serializable') // set of warts to use - violation causes error; default settings from the block above
-            warningWarts.add('Serializable') // set of warts to use - violation causes warning; default settings from the block above
-            excludedFiles.add('src/test/scala/me/project/Test.scala') // set of file to be excluded; default settings from the block above
-            classPaths.add(new File("path/to/yourTestWarts").toURI().toURL().toString()) // set of files or directories to be added to the classpath if using custom warts; default settings from the block above
-	    }
-	}
+
+## Configuration
+
+* `errorWarts.add(<String>)` or `errorWarts.addAll(Collection<String>)` (default is an empty `Set<String>`): 
+  * Set of warts to use which throw <ins>an error</ins> when violated.
+* `warningWarts.add(<String>)` or `warningWarts.addAll(Collection<String>)` (default is a `Set<String>` with all `wartremover:2.x` [Unsafe](https://github.com/wartremover/wartremover/blob/v2.4.21/core/src/main/scala-2/org/wartremover/warts/Unsafe.scala) warts):
+  * Set of warts to use which throw <ins>a warning</ins> when violated.
+* `excludedFiles.add(<String>)` or `excludedFiles.addAll(Collection<String>)` (default is an empty `Set<String>`):
+  * Set of files to be excluded from wartremover coverage.
+* `classPaths.add(<String>)` or `classPaths.addAll(Collection<String>)` (default is an empty `Set<String>`):
+  * Set of files or directories to be added to the classpath if using custom warts.
+* `scalaVersion = <String>` (default `detected`):
+  * Scala version used to denote the wartremover artifact, e.g. `scalaVersion = 2.13.16` -> `wartremover_2.13.16`; `scalaVersion = 2.13` -> `wartremover_2.13`.
+  * Refer to the [Maven Repository](https://mvnrepository.com/artifact/org.wartremover/wartremover) for corresponding artifact versions.
+* `wartremoverVersion = <String>` (default `'2.4.21'` for Scala 2.11+, `2.3.7` for Scala 2.10):
+  * Version of the `org.wartremover` dependency. This plugin is compatible with `2.x` by default, while `3.x` may require manually adding the [different Unsafe](https://github.com/wartremover/wartremover/blob/e8f4fb77aa20ea37a289dbaabf88b38be88e8e26/core/src/main/scala/org/wartremover/warts/Unsafe.scala) warts.
+
+```
+watremover {
+    errorWarts.add('Product')
+    warningWarts.add('Product')
+    excludedFiles.add('src/main/scala/me/project/Main.scala')
+    classPaths.add(new File("path/to/yourWarts").toURI().toURL().toString())
+    scalaVersion = '2.13.16'
+    wartremoverVersion = '2.4.21'
+    test {
+        errorWarts.add('Serializable') // default settings from the block above
+        warningWarts.add('Serializable') // default settings from the block above
+        excludedFiles.add('src/test/scala/me/project/Test.scala') // default settings from the block above
+        classPaths.add(new File("path/to/yourTestWarts").toURI().toURL().toString()) // default settings from the block above
+    }
+}
+```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '1.3.1'
 }
 
-group 'cz.augi'
+group = 'cz.augi'
 version = version == 'unspecified' ? 'DEVELOPER-SNAPSHOT' : version
 
 repositories {
@@ -28,7 +28,7 @@ test {
     useJUnitPlatform()
     testLogging {
         events 'failed'
-        exceptionFormat 'full'
+        exceptionFormat = 'full'
     }
 }
 

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverExtension.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverExtension.groovy
@@ -1,10 +1,12 @@
 package cz.augi.gradle.wartremover
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Project
 
 @CompileStatic
 class WartremoverExtension extends WartremoverSettings {
     private WartremoverSettings testValue = this
+    final Project project
     void test(Closure closure) {
         if (testValue == this) {
             testValue = this.deepClone()
@@ -19,4 +21,10 @@ class WartremoverExtension extends WartremoverSettings {
         }
     }
     WartremoverSettings getTest() { testValue }
+
+    WartremoverExtension(Project project) {
+        this.project = project
+        scalaVersion = project.objects.property(String)
+        wartremoverVersion = project.objects.property(String)
+    }
 }

--- a/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
+++ b/src/main/groovy/cz/augi/gradle/wartremover/WartremoverSettings.groovy
@@ -1,6 +1,7 @@
 package cz.augi.gradle.wartremover
 
 import groovy.transform.CompileStatic
+import org.gradle.api.provider.Property
 
 @CompileStatic
 class WartremoverSettings {
@@ -23,6 +24,8 @@ class WartremoverSettings {
                                 'Var'].toSet()
     Set<String> excludedFiles = []
     Set<String> classPaths = []
+    Property<String> scalaVersion
+    Property<String> wartremoverVersion
 
     WartremoverSettings deepClone() {
         def r = new WartremoverSettings()
@@ -30,6 +33,8 @@ class WartremoverSettings {
         r.warningWarts = this.warningWarts.toSet()
         r.excludedFiles = this.excludedFiles.toSet()
         r.classPaths = this.classPaths.toSet()
-        r
+        r.scalaVersion = this.scalaVersion
+        r.wartremoverVersion = this.wartremoverVersion
+        return r
     }
 }

--- a/src/test/groovy/cz/augi/gradle/wartremover/WartremoverPluginTest.groovy
+++ b/src/test/groovy/cz/augi/gradle/wartremover/WartremoverPluginTest.groovy
@@ -1,21 +1,16 @@
 package cz.augi.gradle.wartremover
 
+import org.gradle.api.Project
 import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class WartremoverPluginTest extends Specification {
     def "add compiler parameters to compiler"() {
-        def project = ProjectBuilder.builder().build()
+        setup:
+        Project project = setupBaseProject('2.10.7')
+
         when:
-        project.plugins.apply 'scala'
-        project.plugins.apply 'wartremover'
-        project.repositories {
-            mavenCentral()
-        }
-        project.dependencies {
-            implementation 'org.scala-lang:scala-library:2.12.15'
-        }
         project.wartremover {
             warningWarts.add('MyProduction')
             test {
@@ -23,29 +18,80 @@ class WartremoverPluginTest extends Specification {
             }
         }
         project.evaluate()
+
         then:
-        assert project.configurations.getByName('scalaCompilerPlugins').dependencies.find { it.name == 'wartremover_2.12.15' }
-        def compileTask = project.tasks.compileScala as ScalaCompile
-        assert compileTask.scalaCompileOptions.additionalParameters.find { it.contains('MyProduction') }
-        assert !compileTask.scalaCompileOptions.additionalParameters.find { it.contains('MyTest') }
-        def compileTestTask = project.tasks.compileTestScala as ScalaCompile
-        assert compileTestTask.scalaCompileOptions.additionalParameters.find { it.contains('MyProduction') }
-        assert compileTestTask.scalaCompileOptions.additionalParameters.find { it.contains('MyTest') }
+        List<String> compileScalaParams = (project.tasks.compileScala as ScalaCompile).scalaCompileOptions.additionalParameters
+        List<String> compileTestScalaParams = (project.tasks.compileTestScala as ScalaCompile).scalaCompileOptions.additionalParameters
+
+        wartremoverDependencyName(project) == "wartremover_2.10"
+        wartremoverDependencyVersion(project) == WartremoverPlugin.wartremoverVersionScala210
+        compileScalaParams.find { it.contains('MyProduction') }
+        !compileScalaParams.find { it.contains('MyTest') }
+        compileTestScalaParams.find { it.contains('MyProduction') }
+        compileTestScalaParams.find { it.contains('MyTest') }
     }
 
     def "should infer compilation target correctly from different compile configurations"() {
-        def project = ProjectBuilder.builder().build()
+        setup:
+        Project project = setupBaseProject('2.11.12')
+
         when:
+        project.evaluate()
+
+        then:
+        wartremoverDependencyName(project) == "wartremover_2.11"
+        wartremoverDependencyVersion(project) == WartremoverPlugin.wartremoverVersionScala211
+    }
+
+    def "should include the user-defined scala version in the wartremover artifact name"() {
+        setup:
+        Project project = setupBaseProject('2.13.15')
+
+        when:
+        project.wartremover {
+            scalaVersion = '2.13.16'
+        }
+        project.evaluate()
+
+        then:
+        wartremoverDependencyName(project) == 'wartremover_2.13.16' // Uses full Scala version when defined by user
+        wartremoverDependencyVersion(project) == WartremoverPlugin.wartremoverVersionScala212Plus
+    }
+
+    def "should set the wartremover artifact version to user-defined wartremover version"() {
+        setup:
+        Project project = setupBaseProject('2.13.15')
+        def testVersion = '2.4.20'
+
+        when:
+        project.wartremover {
+            wartremoverVersion = testVersion
+        }
+        project.evaluate()
+
+        then:
+        wartremoverDependencyName(project) == 'wartremover_2.13'
+        wartremoverDependencyVersion(project) == testVersion
+    }
+
+    private def setupBaseProject(String scalaVersion) {
+        Project project = ProjectBuilder.builder().build()
         project.plugins.apply 'scala'
         project.plugins.apply 'wartremover'
         project.repositories {
             mavenCentral()
         }
         project.dependencies {
-            implementation 'org.scala-lang:scala-library:2.11.12'
+            implementation "org.scala-lang:scala-library:$scalaVersion"
         }
-        project.evaluate()
-        then:
-        assert project.configurations.getByName('scalaCompilerPlugins').dependencies.find { it.name == 'wartremover_2.11.12' }
+        return project
+    }
+
+    private static String wartremoverDependencyName(Project project) {
+        project.configurations.getByName('scalaCompilerPlugins').dependencies.find().name
+    }
+
+    private static String wartremoverDependencyVersion(Project project) {
+        project.configurations.getByName('scalaCompilerPlugins').dependencies.find().version
     }
 }


### PR DESCRIPTION
This also fixes [space assignment](https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax) deprecation warnings in `build.gradle` and expands the documentation for ease-of-use

fix augi/gradle-wartremover#82